### PR TITLE
New Sublayer::Action: JiraGetIssueStatusAction

### DIFF
--- a/Jira/jira_get_issue_status_action.rb
+++ b/Jira/jira_get_issue_status_action.rb
@@ -1,0 +1,39 @@
+require 'jira-ruby'
+
+# Description: Sublayer::Action responsible for retrieving the status of a specific Jira issue.
+# This action allows for checking the current state of an issue, which can be useful for monitoring progress and triggering actions based on status changes.
+#
+# Requires: 'jira-ruby' gem
+# $ gem install jira-ruby
+# Or add `gem 'jira-ruby'` to your Gemfile
+#
+# It is initialized with the issue_key of the Jira issue.
+# It returns the status of the Jira issue (e.g., 'In Progress', 'Done', 'Blocked').
+#
+# Example usage: When you want to track the progress of a Jira issue and perform different actions based on its status within a Sublayer workflow.
+
+class JiraGetIssueStatusAction < Sublayer::Actions::Base
+  def initialize(issue_key:)
+    @issue_key = issue_key
+    @client = JIRA::Client.new(
+      username: ENV['JIRA_USERNAME'],
+      password: ENV['JIRA_API_TOKEN'],
+      site: ENV['JIRA_SITE'],
+      context_path: '',
+      auth_type: :basic
+    )
+  end
+
+  def call
+    begin
+      issue = @client.Issue.find(@issue_key)
+      status = issue.status.name
+      Sublayer.configuration.logger.log(:info, "Successfully retrieved status for Jira issue #{@issue_key}: #{status}")
+      status
+    rescue JIRA::HTTPError => e
+      error_message = "Error fetching Jira issue status: #{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+end


### PR DESCRIPTION
Given a Jira issue key, this action retrieves the status of the issue (e.g., 'In Progress', 'Done', 'Blocked'). Useful for tracking the progress of an issue and triggering different actions based on the status.