### PR TITLE
(gemini): Github: Add Comment to PR Action

### DIFF
--- a/Github/github_add_comment_to_pr_action.rb
+++ b/Github/github_add_comment_to_pr_action.rb
@@ -1,0 +1,18 @@
+class GithubAddCommentToPRAction < GithubBase
+  def initialize(repo:, pr_number:, comment:)
+    super(repo: repo)
+    @pr_number = pr_number
+    @comment = comment
+  end
+
+  def call
+    begin
+      @client.add_comment(@repo, @pr_number, @comment)
+      Sublayer.configuration.logger.log(:info, "Comment added successfully to PR #{@pr_number} in repo #{@repo}")
+    rescue Octokit::Error => e
+      error_message = "Error adding comment to PR: #{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+end


### PR DESCRIPTION
This action would allow an agent to add a comment to an existing Github Pull Request. It would take the PR number or URL and the comment content as input. Useful for AI agents that participate in code reviews or provide feedback on pull requests.