### PR TITLE
(gemini): GitHub Actions Workflow Run Status Retrieval

### DIFF
--- a/Github/github_get_workflow_run_status_action.rb
+++ b/Github/github_get_workflow_run_status_action.rb
@@ -1,0 +1,22 @@
+class GithubGetWorkflowRunStatusAction < GithubBase
+  def initialize(repo:, run_id:)
+    super(repo: repo)
+    @run_id = run_id
+  end
+
+  def call
+    begin
+      run = @client.workflow_run(@repo, @run_id)
+      Sublayer.configuration.logger.log(:info, "Retrieved workflow run status: #{run.status}")
+      run.status
+    rescue Octokit::NotFound => e
+      error_message = "Workflow run not found: \#{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    rescue StandardError => e
+      error_message = "Error fetching workflow run status: \#{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+end


### PR DESCRIPTION
Retrieves the status of a given GitHub Actions workflow run. Useful for monitoring and reacting to the progress of CI/CD pipelines within Sublayer agents.