### PR TITLE
(gemini): Execute Shell Command Action

### DIFF
--- a/System/execute_shell_command_action.rb
+++ b/System/execute_shell_command_action.rb
@@ -1,0 +1,31 @@
+# Description: Sublayer::Action responsible for executing a shell command and returning the standard output, standard error, and exit code.
+#
+# It is initialized with a command to execute.
+# It returns a hash containing the standard output, standard error, and exit code of the command.
+#
+# Example usage: When you want to run system utilities, execute scripts, or interact with external tools from within a Sublayer agent.
+
+class ExecuteShellCommandAction < Sublayer::Actions::Base
+  def initialize(command:)
+    @command = command
+  end
+
+  def call
+    begin
+      stdout, stderr, status = Open3.capture3(@command)
+
+      result = {
+        stdout: stdout,
+        stderr: stderr,
+        exit_code: status.exitstatus
+      }
+
+      Sublayer.configuration.logger.log(:info, "Executed command \"#{@command}\" successfully. Exit code: #{status.exitstatus}")
+      result
+    rescue StandardError => e
+      error_message = "Error executing shell command: #{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+end


### PR DESCRIPTION
Executes a shell command and returns the standard output, standard error, and exit code. This action could be useful for running system utilities, executing scripts, or interacting with external tools from within a Sublayer agent.