### PR TITLE
(claude): GoogleCalendarCreateEventAction

### DIFF
--- a/Google/google_calendar_create_event_action.rb
+++ b/Google/google_calendar_create_event_action.rb
@@ -1,0 +1,86 @@
+require 'google/apis/calendar_v3'
+require 'googleauth'
+
+# Description: Sublayer::Action responsible for creating events in Google Calendar.
+# This action integrates with the Google Calendar API to create calendar events with specified details.
+#
+# Requires: 'google-apis-calendar_v3' and 'googleauth' gems
+# $ gem install google-apis-calendar_v3 googleauth
+# Or add to your Gemfile:
+# gem 'google-apis-calendar_v3'
+# gem 'googleauth'
+#
+# It is initialized with event details including title, start_time, end_time, and optional parameters
+# like description, location, and attendees.
+# It returns the ID of the created calendar event.
+#
+# Example usage: When you want an AI agent to schedule meetings or create calendar events
+# based on conversation context or task requirements.
+
+class GoogleCalendarCreateEventAction < Sublayer::Actions::Base
+  def initialize(title:, start_time:, end_time:, description: nil, location: nil, attendees: [], calendar_id: 'primary')
+    @title = title
+    @start_time = start_time
+    @end_time = end_time
+    @description = description
+    @location = location
+    @attendees = attendees
+    @calendar_id = calendar_id
+    
+    initialize_calendar_service
+  end
+
+  def call
+    begin
+      event = create_event_object
+      result = @service.insert_event(@calendar_id, event)
+      
+      Sublayer.configuration.logger.log(:info, "Calendar event created successfully with ID: #{result.id}")
+      result.id
+    rescue Google::Apis::Error => e
+      error_message = "Error creating calendar event: #{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+
+  private
+
+  def initialize_calendar_service
+    @service = Google::Apis::CalendarV3::CalendarService.new
+    begin
+      # Assumes the credentials file is in the specified location
+      credentials = Google::Auth::ServiceAccountCredentials.make_creds(
+        json_key_io: File.open(ENV['GOOGLE_CALENDAR_CREDENTIALS']),
+        scope: Google::Apis::CalendarV3::AUTH_CALENDAR
+      )
+      @service.authorization = credentials
+    rescue StandardError => e
+      error_message = "Error initializing calendar service: #{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+
+  def create_event_object
+    event = Google::Apis::CalendarV3::Event.new(
+      summary: @title,
+      location: @location,
+      description: @description,
+      start: {
+        date_time: @start_time.iso8601,
+        time_zone: Time.zone.name
+      },
+      end: {
+        date_time: @end_time.iso8601,
+        time_zone: Time.zone.name
+      }
+    )
+
+    unless @attendees.empty?
+      event.attendees = @attendees.map { |email| { email: email } }
+    end
+
+    event
+  end
+end


### PR DESCRIPTION
A Sublayer action that creates calendar events in Google Calendar. This would be useful for AI agents that need to schedule meetings or create reminders based on conversations or task planning. It would integrate with the Google Calendar API to create events with title, description, date/time, and attendees.