### PR TITLE
(claude): GoogleCalendarCreateEventAction

### DIFF
--- a/GoogleCalendar/google_calendar_create_event_action.rb
+++ b/GoogleCalendar/google_calendar_create_event_action.rb
@@ -1,0 +1,77 @@
+require 'google/apis/calendar_v3'
+require 'googleauth'
+
+# Description: Sublayer::Action responsible for creating events in Google Calendar.
+# This action allows for programmatic creation of calendar events with specified details.
+#
+# Requires: 'google-apis-calendar_v3' and 'googleauth' gems
+# $ gem install google-apis-calendar_v3 googleauth
+# Or add to your Gemfile:
+# gem 'google-apis-calendar_v3'
+# gem 'googleauth'
+#
+# It is initialized with event details including title, description, start/end times, and optional attendees.
+# Returns the created event's ID on success.
+#
+# Example usage: When an AI agent needs to schedule meetings or create calendar events
+# based on conversation analysis or task requirements.
+
+class GoogleCalendarCreateEventAction < Sublayer::Actions::Base
+  def initialize(title:, start_time:, end_time:, description: nil, attendees: [], calendar_id: 'primary')
+    @title = title
+    @start_time = start_time
+    @end_time = end_time
+    @description = description
+    @attendees = attendees
+    @calendar_id = calendar_id
+    
+    initialize_client
+  end
+
+  def call
+    begin
+      event = create_event_object
+      result = @service.insert_event(@calendar_id, event)
+      
+      Sublayer.configuration.logger.log(:info, "Successfully created calendar event: #{result.id}")
+      result.id
+    rescue Google::Apis::Error => e
+      error_message = "Error creating Google Calendar event: #{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+
+  private
+
+  def initialize_client
+    @service = Google::Apis::CalendarV3::CalendarService.new
+    
+    # Expects GOOGLE_CALENDAR_CREDENTIALS to contain the path to your service account JSON key file
+    credentials = Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: File.open(ENV['GOOGLE_CALENDAR_CREDENTIALS']),
+      scope: Google::Apis::CalendarV3::AUTH_CALENDAR
+    )
+    
+    @service.authorization = credentials
+  end
+
+  def create_event_object
+    Google::Apis::CalendarV3::Event.new(
+      summary: @title,
+      description: @description,
+      start: {
+        date_time: @start_time.iso8601,
+        time_zone: Time.zone.name
+      },
+      end: {
+        date_time: @end_time.iso8601,
+        time_zone: Time.zone.name
+      },
+      attendees: @attendees.map { |email| { email: email } },
+      reminders: {
+        use_default: true
+      }
+    )
+  end
+end


### PR DESCRIPTION
A Sublayer action that creates calendar events in Google Calendar based on provided details (title, description, start/end times, attendees). This would be useful for AI agents that need to schedule meetings or create calendar events based on conversation or task analysis.