### PR TITLE
(claude): GoogleCalendarEventCreateAction

### DIFF
--- a/Google/google_calendar_event_create_action.rb
+++ b/Google/google_calendar_event_create_action.rb
@@ -1,0 +1,74 @@
+require 'google/apis/calendar_v3'
+require 'googleauth'
+
+# Description: Sublayer::Action responsible for creating events in Google Calendar.
+# This action enables AI agents to programmatically schedule meetings, reminders, or follow-ups.
+#
+# Requires: 'google-apis-calendar_v3' and 'googleauth' gems
+# $ gem install google-apis-calendar_v3 googleauth
+# Or add to your Gemfile:
+# gem 'google-apis-calendar_v3'
+# gem 'googleauth'
+#
+# It is initialized with event details including title, description, start_time, end_time, and optional attendees.
+# It returns the ID of the created event.
+#
+# Example usage: When an AI agent needs to schedule a follow-up meeting based on conversation analysis
+# or create calendar events based on task requirements.
+
+class GoogleCalendarEventCreateAction < Sublayer::Actions::Base
+  def initialize(title:, start_time:, end_time:, description: nil, attendees: [], calendar_id: 'primary')
+    @title = title
+    @start_time = start_time
+    @end_time = end_time
+    @description = description
+    @attendees = attendees
+    @calendar_id = calendar_id
+    
+    @service = initialize_calendar_service
+  end
+
+  def call
+    begin
+      event = create_event_object
+      result = @service.insert_event(@calendar_id, event)
+      
+      Sublayer.configuration.logger.log(:info, "Created calendar event: #{result.id}")
+      result.id
+    rescue Google::Apis::Error => e
+      error_message = "Error creating calendar event: #{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+
+  private
+
+  def initialize_calendar_service
+    service = Google::Apis::CalendarV3::CalendarService.new
+    service.authorization = Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: File.open(ENV['GOOGLE_CALENDAR_CREDENTIALS']),
+      scope: 'https://www.googleapis.com/auth/calendar'
+    )
+    service
+  end
+
+  def create_event_object
+    Google::Apis::CalendarV3::Event.new(
+      summary: @title,
+      description: @description,
+      start: {
+        date_time: @start_time.iso8601,
+        time_zone: 'UTC'
+      },
+      end: {
+        date_time: @end_time.iso8601,
+        time_zone: 'UTC'
+      },
+      attendees: @attendees.map { |email| { email: email } },
+      reminders: {
+        use_default: true
+      }
+    )
+  end
+end


### PR DESCRIPTION
A Sublayer action that creates a Google Calendar event. This would be useful for AI agents that need to schedule follow-ups, meetings, or reminders based on analysis of conversations, tasks, or other inputs. It would take parameters like title, description, start_time, end_time, and attendees.