### PR TITLE
(gemini): ExecuteShellCommandAction

### DIFF
--- a/Shell/execute_shell_command_action.rb
+++ b/Shell/execute_shell_command_action.rb
@@ -1,0 +1,27 @@
+# Description: Sublayer::Action responsible for executing a shell command and returning the standard output, standard error, and exit code.
+# Useful for interacting with the operating system and running external tools.
+
+class ExecuteShellCommandAction < Sublayer::Actions::Base
+  def initialize(command:)
+    @command = command
+  end
+
+  def call
+    begin
+      stdout, stderr, status = Open3.capture3(@command)
+
+      result = {
+        stdout: stdout,
+        stderr: stderr,
+        exit_code: status.exitstatus
+      }
+
+      Sublayer.configuration.logger.log(:info, "Executed command: #{@command}, Exit code: #{status.exitstatus}")
+      result
+    rescue StandardError => e
+      error_message = "Error executing command: #{e.message}"
+      Sublayer.configuration.logger.log(:error, error_message)
+      raise StandardError, error_message
+    end
+  end
+end


### PR DESCRIPTION
Executes a shell command and returns the standard output, standard error, and exit code. Useful for interacting with the operating system and running external tools.